### PR TITLE
Simplify Windows agent setup steps to match Linux pattern

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,12 +17,10 @@ jobs:
           #set 'true' to install .NET Framework SDK and targeting packs (4.7.1 – 4.8.1) on Windows runners, required for .NET Framework or desktop workloads
           install-framework-targeting-packs: 'true'
 
-      - run: |
-          New-Item -ItemType Directory -Force -Path .github\agents | Out-Null
-          @"
-          ---
-          name: modernize-dotnet
-          ---
-          You are a test agent. When invoked, respond only with "Hello World!" and nothing else.
-          "@ | Set-Content -Path .github\agents\modernize-dotnet.agent.md
+      - name: Replace agent file content
+        run: echo "hello world" > .github\agents\modernize-dotnet.agent.md
+        shell: pwsh
+
+      - name: Print agent file contents
+        run: cat .github\agents\modernize-dotnet.agent.md
         shell: pwsh


### PR DESCRIPTION
The Windows job in `copilot-setup-steps.yml` used a verbose PowerShell heredoc to create the agent file, while the Linux equivalent uses two simple named steps. This replaces the Windows step to match that cleaner pattern.

- Replaces the multi-line `pwsh` heredoc with a named "Replace agent file content" step using `echo` redirect
- Adds a named "Print agent file contents" step using `cat` (PowerShell alias for `Get-Content`)

Both steps use `shell: pwsh` for consistency with the Windows runner.